### PR TITLE
[Breaking API change] Support for generics

### DIFF
--- a/asvocab_base_types.go
+++ b/asvocab_base_types.go
@@ -7,7 +7,7 @@ import (
 
 // ObjectOrLink is a wrapper type that represents any type of object or link
 // Single objects are still presented as slices, but with a single element
-type ObjectOrLink []ActivityStreamer
+type ObjectOrLink []ObjectLinker
 
 // ObjectOrLinkOrString is a type that can either represent simple string URL(s) or an Object/Link slice
 type ObjectOrLinkOrString struct {

--- a/asvocab_base_types.go
+++ b/asvocab_base_types.go
@@ -5,9 +5,12 @@ import (
 	"time"
 )
 
-// ObjectOrLink is a wrapper type that represents any type of object or link
+// ObjectOrLink is a wrapper type that represents any valid ActivityStreams 2.0 object or link
 // Single objects are still presented as slices, but with a single element
 type ObjectOrLink []ObjectLinker
+
+// ActivityStream represents a generic collection of valid ActivityStreams 2.0 objects
+type ActivityStream[T ActivityStreamer] []T
 
 // ObjectOrLinkOrString is a type that can either represent simple string URL(s) or an Object/Link slice
 type ObjectOrLinkOrString struct {

--- a/asvocab_interfaces.go
+++ b/asvocab_interfaces.go
@@ -2,25 +2,32 @@ package astreams
 
 import "reflect"
 
-// ActivityStreamer can be either a (sub)type of an 'Object' or 'Link'
-type ActivityStreamer interface {
+// ObjectLinker can be either a (sub)type of 'Object' or a (sub)type of 'Link'
+type ObjectLinker interface {
 	IsObject() bool
 	IsLink() bool
 	GetObject() *Object
 	GetLink() *Link
 }
 
+// ActivityStreamer is a generic type constraint representing all valid Activity Streams 2.0 types
+type ActivityStreamer interface {
+	Object | Link | Actor | Activity | IntransitiveActivity | Collection | CollectionPage |
+		OrderedCollection | OrderedCollectionPage | Location | Icon | Image | Place | Profile |
+		Tombstone | Relationship | PublicKey | Question
+}
+
 // ConcreteType returns both, the type name obtained using reflection,
-// as well as the Type property of the Object/Link.
+// as well as the Type property of the Object / Link.
 // The object's own Type property is going to be more specific, so use that where useful.
-func ConcreteType(t ActivityStreamer) (reflectType, astreamsType string) {
+func ConcreteType(t ObjectLinker) (reflectType, astreamsType string) {
 	if t.IsLink() {
 		return reflect.TypeOf(t).Name(), t.GetLink().Type
 	}
 	return reflect.TypeOf(t).Name(), t.GetObject().Type
 }
 
-// Implements 'ActivityStreamer' interface for 'Object'
+// Implements 'ObjectLinker' interface for 'Object'
 func (o Object) IsObject() bool {
 	return true
 }
@@ -37,7 +44,7 @@ func (o Object) GetLink() *Link {
 	return nil
 }
 
-// Implements 'ActivityStreamer' interface for 'Link'
+// Implements 'ObjectLinker' interface for 'Link'
 func (l Link) IsObject() bool {
 	return false
 }

--- a/asvocab_interfaces.go
+++ b/asvocab_interfaces.go
@@ -12,6 +12,8 @@ type ObjectLinker interface {
 
 // ActivityStreamer is a generic type constraint representing all valid Activity Streams 2.0 types
 type ActivityStreamer interface {
+	ObjectLinker
+
 	Object | Link | Actor | Activity | IntransitiveActivity | Collection | CollectionPage |
 		OrderedCollection | OrderedCollectionPage | Location | Icon | Image | Place | Profile |
 		Tombstone | Relationship | PublicKey | Question

--- a/asvocab_interfaces.go
+++ b/asvocab_interfaces.go
@@ -12,8 +12,6 @@ type ObjectLinker interface {
 
 // ActivityStreamer is a generic type constraint representing all valid Activity Streams 2.0 types
 type ActivityStreamer interface {
-	ObjectLinker
-
 	Object | Link | Actor | Activity | IntransitiveActivity | Collection | CollectionPage |
 		OrderedCollection | OrderedCollectionPage | Location | Icon | Image | Place | Profile |
 		Tombstone | Relationship | PublicKey | Question

--- a/asvocab_serialization.go
+++ b/asvocab_serialization.go
@@ -58,7 +58,7 @@ func (ol *ObjectOrLink) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(data, &asObject); err != nil {
 				return err
 			}
-			*ol = append(*ol, ObjectLinker(asObject))
+			*ol = append(*ol, asObject)
 		}
 	}
 	return nil

--- a/asvocab_serialization.go
+++ b/asvocab_serialization.go
@@ -403,6 +403,38 @@ func (enp *EndpointsOrString) MarshalJSON() ([]byte, error) {
 	return []byte{}, errors.New("unrecognised content, cannot Marshal EndpointsOrString, use nil for empty value")
 }
 
+// UnmarshalJSON is the generic unmarshaller for any valid ActivityStreams 2.0 object
+func (as *ActivityStream[T]) UnmarshalJSON(data []byte) error {
+	if bytes.HasPrefix(bytes.TrimSpace(data), []byte{'['}) {
+		var rawJSONSlice []json.RawMessage
+		if err := json.Unmarshal(data, &rawJSONSlice); err != nil {
+			return err
+		}
+		for _, jsonObj := range rawJSONSlice {
+			var decodedObj T
+			err := json.Unmarshal(jsonObj, &decodedObj)
+			if err != nil {
+				return err
+			}
+			*as = append(*as, decodedObj)
+		}
+	} else if bytes.HasPrefix(bytes.TrimSpace(data), []byte{'{'}) {
+		var decodedObj T
+		err := json.Unmarshal(data, &decodedObj)
+		if err != nil {
+			return err
+		}
+		*as = append(*as, decodedObj)
+	}
+	return nil
+}
+
+// MarshalJSON is the generic marshaller for any valid ActivityStreams 2.0 object
+func MarshalJSON[T ActivityStreamer]() ([]byte, error) {
+	var encodedObj T
+	return json.Marshal(encodedObj)
+}
+
 // Implements https://golang.org/pkg/fmt/#Stringer
 func (ics *Icons) String() string {
 	return fmt.Sprintf("%+v", *ics)

--- a/asvocab_serialization.go
+++ b/asvocab_serialization.go
@@ -35,7 +35,7 @@ func (ol *ObjectOrLink) UnmarshalJSON(data []byte) error {
 				if err := json.Unmarshal(data, &asObject); err != nil {
 					return err
 				}
-				*ol = append(*ol, ActivityStreamer(asObject))
+				*ol = append(*ol, asObject)
 			}
 		}
 	} else if bytes.HasPrefix(bytes.TrimSpace(data), []byte{'{'}) {
@@ -58,7 +58,7 @@ func (ol *ObjectOrLink) UnmarshalJSON(data []byte) error {
 			if err := json.Unmarshal(data, &asObject); err != nil {
 				return err
 			}
-			*ol = append(*ol, ActivityStreamer(asObject))
+			*ol = append(*ol, ObjectLinker(asObject))
 		}
 	}
 	return nil

--- a/asvocab_type_decoder.go
+++ b/asvocab_type_decoder.go
@@ -16,331 +16,331 @@ func decodeASType(data []byte, jsonType string) (ObjectLinker, error) {
 		if err := decoder.Decode(&activity); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(activity), nil
+		return activity, nil
 	case "Application":
 		application := Application{}
 		if err := decoder.Decode(&application); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(application), nil
+		return application, nil
 	case "Article":
 		article := Article{}
 		if err := decoder.Decode(&article); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(article), nil
+		return article, nil
 	case "Audio":
 		audio := Audio{}
 		if err := decoder.Decode(&audio); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(audio), nil
+		return audio, nil
 	case "Collection":
 		collection := Collection{}
 		if err := decoder.Decode(&collection); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(collection), nil
+		return collection, nil
 	case "CollectionPage":
 		colPage := CollectionPage{}
 		if err := decoder.Decode(&colPage); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(colPage), nil
+		return colPage, nil
 	case "Relationship":
 		relationship := Relationship{}
 		if err := decoder.Decode(&relationship); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(relationship), nil
+		return relationship, nil
 	case "Document":
 		document := Document{}
 		if err := decoder.Decode(&document); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(document), nil
+		return document, nil
 	case "Event":
 		event := Event{}
 		if err := decoder.Decode(&event); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(event), nil
+		return event, nil
 	case "Group":
 		group := Group{}
 		if err := decoder.Decode(&group); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(group), nil
+		return group, nil
 	case "Image":
 		image := Image{}
 		if err := decoder.Decode(&image); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(image), nil
+		return image, nil
 	case "IntransitiveActivity":
 		intransitiveActivity := IntransitiveActivity{}
 		if err := decoder.Decode(&intransitiveActivity); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(intransitiveActivity), nil
+		return intransitiveActivity, nil
 	case "Note":
 		note := Note{}
 		if err := decoder.Decode(&note); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(note), nil
+		return note, nil
 	case "Object":
 		object := Object{}
 		if err := decoder.Decode(&object); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(object), nil
+		return object, nil
 	case "OrderedCollection":
 		ordCollection := OrderedCollection{}
 		if err := decoder.Decode(&ordCollection); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(ordCollection), nil
+		return ordCollection, nil
 	case "OrderedCollectionPage":
 		ordColPage := OrderedCollectionPage{}
 		if err := decoder.Decode(&ordColPage); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(ordColPage), nil
+		return ordColPage, nil
 	case "Organization":
 		organization := Organization{}
 		if err := decoder.Decode(&organization); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(organization), nil
+		return organization, nil
 	case "Page":
 		page := Page{}
 		if err := decoder.Decode(&page); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(page), nil
+		return page, nil
 	case "Person":
 		person := Person{}
 		if err := decoder.Decode(&person); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(person), nil
+		return person, nil
 	case "Place":
 		place := Place{}
 		if err := decoder.Decode(&place); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(place), nil
+		return place, nil
 	case "Profile":
 		profile := Profile{}
 		if err := decoder.Decode(&profile); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(profile), nil
+		return profile, nil
 	case "Question":
 		question := Question{}
 		if err := decoder.Decode(&question); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(question), nil
+		return question, nil
 	case "Service":
 		service := Service{}
 		if err := decoder.Decode(&service); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(service), nil
+		return service, nil
 	case "Tombstone":
 		tombStone := Tombstone{}
 		if err := decoder.Decode(&tombStone); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(tombStone), nil
+		return tombStone, nil
 	case "Video":
 		video := Video{}
 		if err := decoder.Decode(&video); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(video), nil
+		return video, nil
 	case "Accept":
 		accept := Accept{}
 		if err := decoder.Decode(&accept); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(accept), nil
+		return accept, nil
 	case "Add":
 		addActivity := Add{}
 		if err := decoder.Decode(&addActivity); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(addActivity), nil
+		return addActivity, nil
 	case "Announce":
 		announce := Announce{}
 		if err := decoder.Decode(&announce); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(announce), nil
+		return announce, nil
 	case "Arrive":
 		arrive := Arrive{}
 		if err := decoder.Decode(&arrive); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(arrive), nil
+		return arrive, nil
 	case "Block":
 		block := Block{}
 		if err := decoder.Decode(&block); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(block), nil
+		return block, nil
 	case "Create":
 		create := Create{}
 		if err := decoder.Decode(&create); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(create), nil
+		return create, nil
 	case "Delete":
 		deleteA := Delete{}
 		if err := decoder.Decode(&deleteA); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(deleteA), nil
+		return deleteA, nil
 	case "Follow":
 		follow := Follow{}
 		if err := decoder.Decode(&follow); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(follow), nil
+		return follow, nil
 	case "Flag":
 		flag := Flag{}
 		if err := decoder.Decode(&flag); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(flag), nil
+		return flag, nil
 	case "Ignore":
 		ignore := Ignore{}
 		if err := decoder.Decode(&ignore); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(ignore), nil
+		return ignore, nil
 	case "Invite":
 		invite := Invite{}
 		if err := decoder.Decode(&invite); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(invite), nil
+		return invite, nil
 	case "Join":
 		join := Join{}
 		if err := decoder.Decode(&join); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(join), nil
+		return join, nil
 	case "Leave":
 		leave := Leave{}
 		if err := decoder.Decode(&leave); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(leave), nil
+		return leave, nil
 	case "Like":
 		like := Like{}
 		if err := decoder.Decode(&like); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(like), nil
+		return like, nil
 	case "Listen":
 		listen := Listen{}
 		if err := decoder.Decode(&listen); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(listen), nil
+		return listen, nil
 	case "Move":
 		move := Move{}
 		if err := decoder.Decode(&move); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(move), nil
+		return move, nil
 	case "Offer":
 		offer := Offer{}
 		if err := decoder.Decode(&offer); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(offer), nil
+		return offer, nil
 	case "Read":
 		read := Read{}
 		if err := decoder.Decode(&read); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(read), nil
+		return read, nil
 	case "Reject":
 		reject := Reject{}
 		if err := decoder.Decode(&reject); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(reject), nil
+		return reject, nil
 	case "Remove":
 		remove := Remove{}
 		if err := decoder.Decode(&remove); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(remove), nil
+		return remove, nil
 	case "TentativeAccept":
 		tentativeAccept := TentativeAccept{}
 		if err := decoder.Decode(&tentativeAccept); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(tentativeAccept), nil
+		return tentativeAccept, nil
 	case "TentativeReject":
 		tentativeReject := TentativeReject{}
 		if err := decoder.Decode(&tentativeReject); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(tentativeReject), nil
+		return tentativeReject, nil
 	case "Travel":
 		travel := Travel{}
 		if err := decoder.Decode(&travel); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(travel), nil
+		return travel, nil
 	case "Undo":
 		undo := Undo{}
 		if err := decoder.Decode(&undo); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(undo), nil
+		return undo, nil
 	case "Update":
 		update := Update{}
 		if err := decoder.Decode(&update); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(update), nil
+		return update, nil
 	case "View":
 		view := View{}
 		if err := decoder.Decode(&view); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(view), nil
+		return view, nil
 	case "Link":
 		link := Link{}
 		if err := decoder.Decode(&link); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(link), nil
+		return link, nil
 	case "Mention":
 		mention := Mention{}
 		if err := decoder.Decode(&mention); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(mention), nil
+		return mention, nil
 	case "Hashtag":
 		hashtag := Hashtag{}
 		if err := decoder.Decode(&hashtag); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(hashtag), nil
+		return hashtag, nil
 	case "PropertyValue":
 		propertyValue := PropertyValue{}
 		if err := decoder.Decode(&propertyValue); err != nil {
 			return nil, err
 		}
-		return ObjectLinker(propertyValue), nil
+		return propertyValue, nil
 	}
 	return nil, errors.New("unsupported ActivityStreams type, or invalid AS document")
 }

--- a/asvocab_type_decoder.go
+++ b/asvocab_type_decoder.go
@@ -198,11 +198,11 @@ func decodeASType(data []byte, jsonType string) (ObjectLinker, error) {
 		}
 		return create, nil
 	case "Delete":
-		deleteA := Delete{}
-		if err := decoder.Decode(&deleteA); err != nil {
+		deleteActivity := Delete{}
+		if err := decoder.Decode(&deleteActivity); err != nil {
 			return nil, err
 		}
-		return deleteA, nil
+		return deleteActivity, nil
 	case "Follow":
 		follow := Follow{}
 		if err := decoder.Decode(&follow); err != nil {

--- a/asvocab_type_decoder.go
+++ b/asvocab_type_decoder.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Decode the supplied JSON into the appropriate type based on its "type" property
-func decodeASType(data []byte, jsonType string) (ActivityStreamer, error) {
+func decodeASType(data []byte, jsonType string) (ObjectLinker, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
 	switch jsonType {
@@ -16,331 +16,331 @@ func decodeASType(data []byte, jsonType string) (ActivityStreamer, error) {
 		if err := decoder.Decode(&activity); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(activity), nil
+		return ObjectLinker(activity), nil
 	case "Application":
 		application := Application{}
 		if err := decoder.Decode(&application); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(application), nil
+		return ObjectLinker(application), nil
 	case "Article":
 		article := Article{}
 		if err := decoder.Decode(&article); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(article), nil
+		return ObjectLinker(article), nil
 	case "Audio":
 		audio := Audio{}
 		if err := decoder.Decode(&audio); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(audio), nil
+		return ObjectLinker(audio), nil
 	case "Collection":
 		collection := Collection{}
 		if err := decoder.Decode(&collection); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(collection), nil
+		return ObjectLinker(collection), nil
 	case "CollectionPage":
 		colPage := CollectionPage{}
 		if err := decoder.Decode(&colPage); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(colPage), nil
+		return ObjectLinker(colPage), nil
 	case "Relationship":
 		relationship := Relationship{}
 		if err := decoder.Decode(&relationship); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(relationship), nil
+		return ObjectLinker(relationship), nil
 	case "Document":
 		document := Document{}
 		if err := decoder.Decode(&document); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(document), nil
+		return ObjectLinker(document), nil
 	case "Event":
 		event := Event{}
 		if err := decoder.Decode(&event); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(event), nil
+		return ObjectLinker(event), nil
 	case "Group":
 		group := Group{}
 		if err := decoder.Decode(&group); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(group), nil
+		return ObjectLinker(group), nil
 	case "Image":
 		image := Image{}
 		if err := decoder.Decode(&image); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(image), nil
+		return ObjectLinker(image), nil
 	case "IntransitiveActivity":
 		intransitiveActivity := IntransitiveActivity{}
 		if err := decoder.Decode(&intransitiveActivity); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(intransitiveActivity), nil
+		return ObjectLinker(intransitiveActivity), nil
 	case "Note":
 		note := Note{}
 		if err := decoder.Decode(&note); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(note), nil
+		return ObjectLinker(note), nil
 	case "Object":
 		object := Object{}
 		if err := decoder.Decode(&object); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(object), nil
+		return ObjectLinker(object), nil
 	case "OrderedCollection":
 		ordCollection := OrderedCollection{}
 		if err := decoder.Decode(&ordCollection); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(ordCollection), nil
+		return ObjectLinker(ordCollection), nil
 	case "OrderedCollectionPage":
 		ordColPage := OrderedCollectionPage{}
 		if err := decoder.Decode(&ordColPage); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(ordColPage), nil
+		return ObjectLinker(ordColPage), nil
 	case "Organization":
 		organization := Organization{}
 		if err := decoder.Decode(&organization); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(organization), nil
+		return ObjectLinker(organization), nil
 	case "Page":
 		page := Page{}
 		if err := decoder.Decode(&page); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(page), nil
+		return ObjectLinker(page), nil
 	case "Person":
 		person := Person{}
 		if err := decoder.Decode(&person); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(person), nil
+		return ObjectLinker(person), nil
 	case "Place":
 		place := Place{}
 		if err := decoder.Decode(&place); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(place), nil
+		return ObjectLinker(place), nil
 	case "Profile":
 		profile := Profile{}
 		if err := decoder.Decode(&profile); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(profile), nil
+		return ObjectLinker(profile), nil
 	case "Question":
 		question := Question{}
 		if err := decoder.Decode(&question); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(question), nil
+		return ObjectLinker(question), nil
 	case "Service":
 		service := Service{}
 		if err := decoder.Decode(&service); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(service), nil
+		return ObjectLinker(service), nil
 	case "Tombstone":
 		tombStone := Tombstone{}
 		if err := decoder.Decode(&tombStone); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(tombStone), nil
+		return ObjectLinker(tombStone), nil
 	case "Video":
 		video := Video{}
 		if err := decoder.Decode(&video); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(video), nil
+		return ObjectLinker(video), nil
 	case "Accept":
 		accept := Accept{}
 		if err := decoder.Decode(&accept); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(accept), nil
+		return ObjectLinker(accept), nil
 	case "Add":
 		addActivity := Add{}
 		if err := decoder.Decode(&addActivity); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(addActivity), nil
+		return ObjectLinker(addActivity), nil
 	case "Announce":
 		announce := Announce{}
 		if err := decoder.Decode(&announce); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(announce), nil
+		return ObjectLinker(announce), nil
 	case "Arrive":
 		arrive := Arrive{}
 		if err := decoder.Decode(&arrive); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(arrive), nil
+		return ObjectLinker(arrive), nil
 	case "Block":
 		block := Block{}
 		if err := decoder.Decode(&block); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(block), nil
+		return ObjectLinker(block), nil
 	case "Create":
 		create := Create{}
 		if err := decoder.Decode(&create); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(create), nil
+		return ObjectLinker(create), nil
 	case "Delete":
 		deleteA := Delete{}
 		if err := decoder.Decode(&deleteA); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(deleteA), nil
+		return ObjectLinker(deleteA), nil
 	case "Follow":
 		follow := Follow{}
 		if err := decoder.Decode(&follow); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(follow), nil
+		return ObjectLinker(follow), nil
 	case "Flag":
 		flag := Flag{}
 		if err := decoder.Decode(&flag); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(flag), nil
+		return ObjectLinker(flag), nil
 	case "Ignore":
 		ignore := Ignore{}
 		if err := decoder.Decode(&ignore); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(ignore), nil
+		return ObjectLinker(ignore), nil
 	case "Invite":
 		invite := Invite{}
 		if err := decoder.Decode(&invite); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(invite), nil
+		return ObjectLinker(invite), nil
 	case "Join":
 		join := Join{}
 		if err := decoder.Decode(&join); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(join), nil
+		return ObjectLinker(join), nil
 	case "Leave":
 		leave := Leave{}
 		if err := decoder.Decode(&leave); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(leave), nil
+		return ObjectLinker(leave), nil
 	case "Like":
 		like := Like{}
 		if err := decoder.Decode(&like); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(like), nil
+		return ObjectLinker(like), nil
 	case "Listen":
 		listen := Listen{}
 		if err := decoder.Decode(&listen); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(listen), nil
+		return ObjectLinker(listen), nil
 	case "Move":
 		move := Move{}
 		if err := decoder.Decode(&move); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(move), nil
+		return ObjectLinker(move), nil
 	case "Offer":
 		offer := Offer{}
 		if err := decoder.Decode(&offer); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(offer), nil
+		return ObjectLinker(offer), nil
 	case "Read":
 		read := Read{}
 		if err := decoder.Decode(&read); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(read), nil
+		return ObjectLinker(read), nil
 	case "Reject":
 		reject := Reject{}
 		if err := decoder.Decode(&reject); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(reject), nil
+		return ObjectLinker(reject), nil
 	case "Remove":
 		remove := Remove{}
 		if err := decoder.Decode(&remove); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(remove), nil
+		return ObjectLinker(remove), nil
 	case "TentativeAccept":
 		tentativeAccept := TentativeAccept{}
 		if err := decoder.Decode(&tentativeAccept); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(tentativeAccept), nil
+		return ObjectLinker(tentativeAccept), nil
 	case "TentativeReject":
 		tentativeReject := TentativeReject{}
 		if err := decoder.Decode(&tentativeReject); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(tentativeReject), nil
+		return ObjectLinker(tentativeReject), nil
 	case "Travel":
 		travel := Travel{}
 		if err := decoder.Decode(&travel); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(travel), nil
+		return ObjectLinker(travel), nil
 	case "Undo":
 		undo := Undo{}
 		if err := decoder.Decode(&undo); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(undo), nil
+		return ObjectLinker(undo), nil
 	case "Update":
 		update := Update{}
 		if err := decoder.Decode(&update); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(update), nil
+		return ObjectLinker(update), nil
 	case "View":
 		view := View{}
 		if err := decoder.Decode(&view); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(view), nil
+		return ObjectLinker(view), nil
 	case "Link":
 		link := Link{}
 		if err := decoder.Decode(&link); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(link), nil
+		return ObjectLinker(link), nil
 	case "Mention":
 		mention := Mention{}
 		if err := decoder.Decode(&mention); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(mention), nil
+		return ObjectLinker(mention), nil
 	case "Hashtag":
 		hashtag := Hashtag{}
 		if err := decoder.Decode(&hashtag); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(hashtag), nil
+		return ObjectLinker(hashtag), nil
 	case "PropertyValue":
 		propertyValue := PropertyValue{}
 		if err := decoder.Decode(&propertyValue); err != nil {
 			return nil, err
 		}
-		return ActivityStreamer(propertyValue), nil
+		return ObjectLinker(propertyValue), nil
 	}
 	return nil, errors.New("unsupported ActivityStreams type, or invalid AS document")
 }

--- a/asvocab_type_encoder.go
+++ b/asvocab_type_encoder.go
@@ -505,7 +505,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 		}
 		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
 	case "PropertyValue":
-		if propertyValue, ok := t.(Mention); ok {
+		if propertyValue, ok := t.(PropertyValue); ok {
 			marshalB, err := json.Marshal(propertyValue)
 			if err != nil {
 				return []byte{}, err

--- a/asvocab_type_encoder.go
+++ b/asvocab_type_encoder.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-func encodeASType(t ActivityStreamer) ([]byte, error) {
+func encodeASType(t ObjectLinker) ([]byte, error) {
 	datatType, _ := ConcreteType(t)
 	switch datatType {
 	case "Activity":

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/MatejLach/astreams
 
-go 1.14
+go 1.18


### PR DESCRIPTION
Initial support for generics:

- `ActivityStreamer` is now a generic type constraining interface of all the valid ActivityStreams 2.0 objects.
- The existing functionality of `ActivityStreamer` has been replaced by the `ObjectLinker` interface.
- New `ActivityStream` type as a parametrized counterpart to the `ObjectOrLink` type.
- Variants of `UnmarshalJSON` and `MarshalJSON` generic over types that satisfy the `ActivityStreamer` type constraint.
- Minor cleanups/fixes. 

As a result of the above changes, you'll need to rename all your usage of `ActivityStreamer` to `ObjectLinker`. Further changes should only be necessary if you wish to take advantage of generics. 