### PR TITLE
Improvements & fixes when utilizing generics

### DIFF
--- a/asvocab_base_types.go
+++ b/asvocab_base_types.go
@@ -9,9 +9,6 @@ import (
 // Single objects are still presented as slices, but with a single element
 type ObjectOrLink []ObjectLinker
 
-// ActivityStream represents a generic collection of valid ActivityStreams 2.0 objects
-type ActivityStream[T ActivityStreamer] []T
-
 // ObjectOrLinkOrString is a type that can either represent simple string URL(s) or an Object/Link slice
 type ObjectOrLinkOrString struct {
 	URL    []string

--- a/asvocab_interfaces.go
+++ b/asvocab_interfaces.go
@@ -1,13 +1,13 @@
 package astreams
 
-import "reflect"
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+)
 
-// ObjectLinker can be either a (sub)type of 'Object' or a (sub)type of 'Link'
-type ObjectLinker interface {
-	IsObject() bool
-	IsLink() bool
-	GetObject() *Object
-	GetLink() *Link
+type JsonPayload struct {
+	Type string `json:"type"`
 }
 
 // ActivityStreamer is a generic type constraint representing all valid Activity Streams 2.0 types
@@ -17,8 +17,26 @@ type ActivityStreamer interface {
 		Tombstone | Relationship | PublicKey | Question
 }
 
+func DecodePayloadObjectType(payload io.Reader) (JsonPayload, error) {
+	var payloadType JsonPayload
+	err := json.NewDecoder(payload).Decode(&payloadType)
+	if err != nil {
+		return payloadType, err
+	}
+
+	return payloadType, nil
+}
+
+// ObjectLinker can be either a (sub)type of 'Object' or a (sub)type of 'Link'
+type ObjectLinker interface {
+	IsObject() bool
+	IsLink() bool
+	GetObject() *Object
+	GetLink() *Link
+}
+
 // ConcreteType returns both, the type name obtained using reflection,
-// as well as the Type property of the Object / Link.
+// and the Type property of the Object / Link JSON payload.
 // The object's own Type property is going to be more specific, so use that where useful.
 func ConcreteType(t ObjectLinker) (reflectType, astreamsType string) {
 	if t.IsLink() {

--- a/asvocab_interfaces.go
+++ b/asvocab_interfaces.go
@@ -17,6 +17,44 @@ type ActivityStreamer interface {
 		Tombstone | Relationship | PublicKey | Question
 }
 
+// DecodePayloadObjectType can be used to check the specific type of unknown JSON payload
+/*
+	payloadMeta, err := DecodePayloadObjectType(payload)
+	if err != nil {
+		//
+	}
+
+	switch payloadMeta.Type {
+	case "Note":
+		var note Note
+		err = json.Unmarshal([]byte(tc), &note)
+		if err != nil {
+			//
+		}
+	case "Offer":
+		var offer Offer
+		err = json.Unmarshal([]byte(tc), &offer)
+		if err != nil {
+			//
+		}
+	case "Person":
+		var person Person
+		err = json.Unmarshal([]byte(tc), &person)
+		if err != nil {
+			//
+		}
+
+		if person.Name == "" {
+			//
+		}
+	default:
+		var obj ObjectOrLinkOrString
+		err = json.Unmarshal([]byte(tc), &obj)
+		if err != nil {
+			//
+		}
+	}
+*/
 func DecodePayloadObjectType(payload io.Reader) (JsonPayload, error) {
 	var payloadType JsonPayload
 	err := json.NewDecoder(payload).Decode(&payloadType)

--- a/asvocab_serialization.go
+++ b/asvocab_serialization.go
@@ -30,7 +30,7 @@ func (ol *ObjectOrLink) UnmarshalJSON(data []byte) error {
 					*ol = append(*ol, astype)
 				}
 			} else {
-				// assuming a generic Object if there's not a more specific type
+				// assuming a base Object if there's not a more specific type
 				// a Link without an explicit type is considered invalid
 				asObject := Object{}
 				if err := json.Unmarshal(data, &asObject); err != nil {

--- a/asvocab_serialization.go
+++ b/asvocab_serialization.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 )
 
@@ -52,7 +53,7 @@ func (ol *ObjectOrLink) UnmarshalJSON(data []byte) error {
 				*ol = append(*ol, astype)
 			}
 		} else {
-			// assuming a generic Object if there's not a more specific type
+			// assuming a base Object if there's not a more specific type
 			// a Link without an explicit type is considered invalid
 			asObject := Object{}
 			if err := json.Unmarshal(data, &asObject); err != nil {
@@ -403,36 +404,21 @@ func (enp *EndpointsOrString) MarshalJSON() ([]byte, error) {
 	return []byte{}, errors.New("unrecognised content, cannot Marshal EndpointsOrString, use nil for empty value")
 }
 
-// UnmarshalJSON is the generic unmarshaller for any valid ActivityStreams 2.0 object
-func (as *ActivityStream[T]) UnmarshalJSON(data []byte) error {
-	if bytes.HasPrefix(bytes.TrimSpace(data), []byte{'['}) {
-		var rawJSONSlice []json.RawMessage
-		if err := json.Unmarshal(data, &rawJSONSlice); err != nil {
-			return err
-		}
-		for _, jsonObj := range rawJSONSlice {
-			var decodedObj T
-			err := json.Unmarshal(jsonObj, &decodedObj)
-			if err != nil {
-				return err
-			}
-			*as = append(*as, decodedObj)
-		}
-	} else if bytes.HasPrefix(bytes.TrimSpace(data), []byte{'{'}) {
-		var decodedObj T
-		err := json.Unmarshal(data, &decodedObj)
-		if err != nil {
-			return err
-		}
-		*as = append(*as, decodedObj)
+// DecodeJSON is the generic unmarshaller for any valid ActivityStreams 2.0 object
+func DecodeJSON[T ActivityStreamer](jsonPayload io.Reader) (T, error) {
+	var result T
+
+	err := json.NewDecoder(jsonPayload).Decode(&result)
+	if err != nil {
+		return result, err
 	}
-	return nil
+
+	return result, nil
 }
 
-// MarshalJSON is the generic marshaller for any valid ActivityStreams 2.0 object
-func MarshalJSON[T ActivityStreamer]() ([]byte, error) {
-	var encodedObj T
-	return json.Marshal(encodedObj)
+// EncodeJSON is the generic marshaller for any valid ActivityStreams 2.0 object
+func EncodeJSON[T ActivityStreamer](toEncode T) ([]byte, error) {
+	return json.Marshal(toEncode)
 }
 
 // Implements https://golang.org/pkg/fmt/#Stringer

--- a/asvocab_serialization_unmarshal_test.go
+++ b/asvocab_serialization_unmarshal_test.go
@@ -2,6 +2,7 @@ package astreams
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -55,8 +56,6 @@ func TestUnmarshalJSON_ObjectOrLink(t *testing.T) {
 }
 
 func TestUnmarshalJSON_ObjectOrLinkOrString(t *testing.T) {
-	var obj ObjectOrLinkOrString
-	var err error
 	testCases := []string{
 		`{
   "@context": [
@@ -278,9 +277,40 @@ func TestUnmarshalJSON_ObjectOrLinkOrString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err = json.Unmarshal([]byte(tc), &obj)
+		payloadMeta, err := DecodePayloadObjectType(strings.NewReader(tc))
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		switch payloadMeta.Type {
+		case "Note":
+			var note Note
+			err = json.Unmarshal([]byte(tc), &note)
+			if err != nil {
+				t.Fatal(err)
+			}
+		case "Offer":
+			var offer Offer
+			err = json.Unmarshal([]byte(tc), &offer)
+			if err != nil {
+				t.Fatal(err)
+			}
+		case "Person":
+			var person Person
+			err = json.Unmarshal([]byte(tc), &person)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if person.Name == "" {
+				t.Fatal(err)
+			}
+		default:
+			var obj ObjectOrLinkOrString
+			err = json.Unmarshal([]byte(tc), &obj)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 }

--- a/asvocab_type_encoder.go
+++ b/asvocab_type_encoder.go
@@ -7,8 +7,8 @@ import (
 )
 
 func encodeASType(t ObjectLinker) ([]byte, error) {
-	datatType, _ := ConcreteType(t)
-	switch datatType {
+	dataType, _ := ConcreteType(t)
+	switch dataType {
 	case "Activity":
 		if activity, ok := t.(Activity); ok {
 			marshalB, err := json.Marshal(activity)
@@ -17,7 +17,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Application":
 		if application, ok := t.(Application); ok {
 			marshalB, err := json.Marshal(application)
@@ -26,7 +26,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Article":
 		if article, ok := t.(Article); ok {
 			marshalB, err := json.Marshal(article)
@@ -35,7 +35,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Audio":
 		if audio, ok := t.(Audio); ok {
 			marshalB, err := json.Marshal(audio)
@@ -44,7 +44,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Collection":
 		if collection, ok := t.(Collection); ok {
 			marshalB, err := json.Marshal(collection)
@@ -53,7 +53,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "CollectionPage":
 		if colPage, ok := t.(CollectionPage); ok {
 			marshalB, err := json.Marshal(colPage)
@@ -62,7 +62,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Relationship":
 		if relationship, ok := t.(Relationship); ok {
 			marshalB, err := json.Marshal(relationship)
@@ -71,7 +71,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Document":
 		if document, ok := t.(Document); ok {
 			marshalB, err := json.Marshal(document)
@@ -80,7 +80,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Event":
 		if event, ok := t.(Event); ok {
 			marshalB, err := json.Marshal(event)
@@ -89,7 +89,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Group":
 		if group, ok := t.(Group); ok {
 			marshalB, err := json.Marshal(group)
@@ -98,7 +98,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Image":
 		if image, ok := t.(Image); ok {
 			marshalB, err := json.Marshal(image)
@@ -107,7 +107,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "IntransitiveActivity":
 		if intransitiveActivity, ok := t.(IntransitiveActivity); ok {
 			marshalB, err := json.Marshal(intransitiveActivity)
@@ -116,7 +116,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Note":
 		if note, ok := t.(Note); ok {
 			marshalB, err := json.Marshal(note)
@@ -125,7 +125,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Object":
 		if object, ok := t.(Object); ok {
 			marshalB, err := json.Marshal(object)
@@ -134,7 +134,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "OrderedCollection":
 		if ordCollection, ok := t.(OrderedCollection); ok {
 			marshalB, err := json.Marshal(ordCollection)
@@ -143,7 +143,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "OrderedCollectionPage":
 		if ordColPage, ok := t.(OrderedCollectionPage); ok {
 			marshalB, err := json.Marshal(ordColPage)
@@ -152,7 +152,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Organization":
 		if organization, ok := t.(Organization); ok {
 			marshalB, err := json.Marshal(organization)
@@ -161,7 +161,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Page":
 		if page, ok := t.(Page); ok {
 			marshalB, err := json.Marshal(page)
@@ -170,7 +170,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Person":
 		if person, ok := t.(Person); ok {
 			marshalB, err := json.Marshal(person)
@@ -179,7 +179,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Place":
 		if place, ok := t.(Place); ok {
 			marshalB, err := json.Marshal(place)
@@ -188,7 +188,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Profile":
 		if profile, ok := t.(Profile); ok {
 			marshalB, err := json.Marshal(profile)
@@ -197,7 +197,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Question":
 		if question, ok := t.(Question); ok {
 			marshalB, err := json.Marshal(question)
@@ -206,7 +206,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Service":
 		if service, ok := t.(Service); ok {
 			marshalB, err := json.Marshal(service)
@@ -215,7 +215,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Tombstone":
 		if tombstone, ok := t.(Tombstone); ok {
 			marshalB, err := json.Marshal(tombstone)
@@ -224,7 +224,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Video":
 		if video, ok := t.(Video); ok {
 			marshalB, err := json.Marshal(video)
@@ -233,7 +233,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Accept":
 		if accept, ok := t.(Accept); ok {
 			marshalB, err := json.Marshal(accept)
@@ -242,7 +242,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Add":
 		if add, ok := t.(Add); ok {
 			marshalB, err := json.Marshal(add)
@@ -251,7 +251,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Announce":
 		if announce, ok := t.(Announce); ok {
 			marshalB, err := json.Marshal(announce)
@@ -260,7 +260,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Arrive":
 		if arrive, ok := t.(Arrive); ok {
 			marshalB, err := json.Marshal(arrive)
@@ -269,7 +269,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Block":
 		if block, ok := t.(Block); ok {
 			marshalB, err := json.Marshal(block)
@@ -278,7 +278,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Create":
 		if create, ok := t.(Create); ok {
 			marshalB, err := json.Marshal(create)
@@ -287,7 +287,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Delete":
 		if del, ok := t.(Delete); ok {
 			marshalB, err := json.Marshal(del)
@@ -296,7 +296,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Dislike":
 		if dislike, ok := t.(Dislike); ok {
 			marshalB, err := json.Marshal(dislike)
@@ -305,7 +305,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Follow":
 		if follow, ok := t.(Follow); ok {
 			marshalB, err := json.Marshal(follow)
@@ -314,7 +314,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Flag":
 		if flag, ok := t.(Flag); ok {
 			marshalB, err := json.Marshal(flag)
@@ -323,7 +323,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Ignore":
 		if ignore, ok := t.(Ignore); ok {
 			marshalB, err := json.Marshal(ignore)
@@ -332,7 +332,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Invite":
 		if invite, ok := t.(Invite); ok {
 			marshalB, err := json.Marshal(invite)
@@ -341,7 +341,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Join":
 		if join, ok := t.(Join); ok {
 			marshalB, err := json.Marshal(join)
@@ -350,7 +350,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Leave":
 		if leave, ok := t.(Leave); ok {
 			marshalB, err := json.Marshal(leave)
@@ -359,7 +359,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Like":
 		if like, ok := t.(Like); ok {
 			marshalB, err := json.Marshal(like)
@@ -368,7 +368,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Listen":
 		if listen, ok := t.(Listen); ok {
 			marshalB, err := json.Marshal(listen)
@@ -377,7 +377,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Move":
 		if move, ok := t.(Move); ok {
 			marshalB, err := json.Marshal(move)
@@ -386,7 +386,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Offer":
 		if offer, ok := t.(Offer); ok {
 			marshalB, err := json.Marshal(offer)
@@ -395,7 +395,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Read":
 		if read, ok := t.(Read); ok {
 			marshalB, err := json.Marshal(read)
@@ -404,7 +404,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Reject":
 		if reject, ok := t.(Reject); ok {
 			marshalB, err := json.Marshal(reject)
@@ -413,7 +413,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Remove":
 		if remove, ok := t.(Remove); ok {
 			marshalB, err := json.Marshal(remove)
@@ -422,7 +422,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "TentativeAccept":
 		if tentativeAccept, ok := t.(TentativeAccept); ok {
 			marshalB, err := json.Marshal(tentativeAccept)
@@ -431,7 +431,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "TentativeReject":
 		if tentativeReject, ok := t.(TentativeReject); ok {
 			marshalB, err := json.Marshal(tentativeReject)
@@ -440,7 +440,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Travel":
 		if travel, ok := t.(Travel); ok {
 			marshalB, err := json.Marshal(travel)
@@ -449,7 +449,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Undo":
 		if undo, ok := t.(Undo); ok {
 			marshalB, err := json.Marshal(undo)
@@ -458,7 +458,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Update":
 		if update, ok := t.(Update); ok {
 			marshalB, err := json.Marshal(update)
@@ -467,7 +467,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "View":
 		if view, ok := t.(View); ok {
 			marshalB, err := json.Marshal(view)
@@ -476,7 +476,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Link":
 		if link, ok := t.(Link); ok {
 			marshalB, err := json.Marshal(link)
@@ -485,7 +485,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Mention":
 		if mention, ok := t.(Mention); ok {
 			marshalB, err := json.Marshal(mention)
@@ -494,7 +494,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "Hashtag":
 		if hashtag, ok := t.(Hashtag); ok {
 			marshalB, err := json.Marshal(hashtag)
@@ -503,7 +503,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	case "PropertyValue":
 		if propertyValue, ok := t.(PropertyValue); ok {
 			marshalB, err := json.Marshal(propertyValue)
@@ -512,7 +512,7 @@ func encodeASType(t ObjectLinker) ([]byte, error) {
 			}
 			return marshalB, nil
 		}
-		return []byte{}, fmt.Errorf("failed to Marshal %s", datatType)
+		return []byte{}, fmt.Errorf("failed to Marshal %s", dataType)
 	}
 	return []byte{}, errors.New("unsupported ActivityStreams type, or invalid AS document")
 }


### PR DESCRIPTION
Continuing the work started in #2, this pull request improves upon the generics enabled API surface. 

The main changes are:

- Removal of the `ActivityStream` type as its practical use case isn't clear. 
- Introduction of the `DecodePayloadObjectType` function, which can be used to inspect the specific Activity Streams/Vocabulary type of an incoming JSON payload. 
- `DecodeJSON` and `EncodeJSON` are generic functions that can be used to encode/decode any `ActivityStreamer` object. 

Various fixes, test improvements etc. 